### PR TITLE
ENH: update import to use new module name

### DIFF
--- a/artifact_tool.py
+++ b/artifact_tool.py
@@ -5,7 +5,7 @@ import os.path
 from functools import lru_cache, partial
 from types import SimpleNamespace
 
-import ceam_inputs
+import vivarium_inputs as ceam_inputs
 from gbd_mapping import covariates
 from vivarium_gbd_access import gbd
 


### PR DESCRIPTION
I don't know where the `from gbd_mapping import covariates` import came from... I kept it in case you meant to add it for something, but I suspect that is something I added when I was testing, and forgot to remove.